### PR TITLE
Add security v2 support

### DIFF
--- a/cpp/client/README.md
+++ b/cpp/client/README.md
@@ -226,7 +226,7 @@ Producer will generate two log files:
 </details>
 
 <pre>
-$ cp <producer-ndnrtc-cpp-folder>/tests/policy_config/signing.cert <consumer-ndnrtc-cpp-folder>/tests/policy_config
+$ cp tests/policy_config/signing.cert tests/policy_config
 </pre>
 
 <details>

--- a/cpp/client/README.md
+++ b/cpp/client/README.md
@@ -225,9 +225,7 @@ Producer will generate two log files:
  > Nothing's here :neckbeard:
 </details>
 
-<pre>
-$ cp tests/policy_config/signing.cert tests/policy_config
-</pre>
+    $ cp <producer-ndn-rtc-cpp-folder>/tests/policy_config/signing.cert <consumer-ndn-rtc-cpp-folder>/tests/policy_config
 
 <details>
  <summary>#4 <b>Run consumer</b></summary>

--- a/cpp/client/src/key-chain-manager.cpp
+++ b/cpp/client/src/key-chain-manager.cpp
@@ -47,8 +47,12 @@ void KeyChainManager::setupInstanceKeyChain()
 	Name signingIdentity(signingIdentity_);
 	std::vector<Name> identities;
 
-	defaultKeyChain_->getIdentityManager()->getAllIdentities(identities, false);
-	defaultKeyChain_->getIdentityManager()->getAllIdentities(identities, true);
+	if (defaultKeyChain_->getIsSecurityV1()) {
+		defaultKeyChain_->getIdentityManager()->getAllIdentities(identities, false);
+		defaultKeyChain_->getIdentityManager()->getAllIdentities(identities, true);
+	}
+    else
+		defaultKeyChain_->getPib().getAllIdentityNames(identities);
 
 	if (std::find(identities.begin(), identities.end(), signingIdentity) == identities.end())
 	{

--- a/cpp/client/src/key-chain-manager.hpp
+++ b/cpp/client/src/key-chain-manager.hpp
@@ -53,6 +53,7 @@ private:
 	void createSigningIdentity();
 	void createMemoryKeychain();
 	void createInstanceIdentity();
+	void createInstanceIdentityV2();
     void checkExists(const std::string&);
 };
 

--- a/cpp/client/src/key-chain-manager.hpp
+++ b/cpp/client/src/key-chain-manager.hpp
@@ -13,7 +13,7 @@
 namespace ndn {
 	class KeyChain;
     class Face;
-    class IdentityCertificate;
+    class Data;
     class ConfigPolicyManager;
     class IdentityStorage;
     class PrivateKeyStorage;
@@ -31,7 +31,7 @@ public:
 	boost::shared_ptr<ndn::KeyChain> instanceKeyChain() { return instanceKeyChain_; }
     std::string instancePrefix() const { return instanceIdentity_; }
     
-    const boost::shared_ptr<ndn::IdentityCertificate> instanceCertificate() const
+    const boost::shared_ptr<ndn::Data> instanceCertificate() const
         { return instanceCert_; }
     
 private:
@@ -42,7 +42,8 @@ private:
 
     boost::shared_ptr<ndn::ConfigPolicyManager> configPolicyManager_;
 	boost::shared_ptr<ndn::KeyChain> defaultKeyChain_, instanceKeyChain_;
-    boost::shared_ptr<ndn::IdentityCertificate> instanceCert_;
+    // instanceCert_ is a certificate subclass of Data.
+    boost::shared_ptr<ndn::Data> instanceCert_;
     boost::shared_ptr<ndn::IdentityStorage> identityStorage_;
     boost::shared_ptr<ndn::PrivateKeyStorage> privateKeyStorage_;
 


### PR DESCRIPTION
In the client app, added support for security v2, mainly in KeyChainManager by adding createInstanceIdentityV2. If the defaultKeyChain_ is security v2, use createInstanceIdentityV2 and set instanceKeyChain_ to a security v2 KeyChain.